### PR TITLE
Revert "use envDir instead of dotenv in `vite.config`"

### DIFF
--- a/src/helpers/vite.ts
+++ b/src/helpers/vite.ts
@@ -14,7 +14,8 @@ export const getViteConfig: IUtil = (ctx) => {
       : useUno
       ? `[solid({ ssr: ${shouldUseSSR} }), UnoCSS()]`
       : `[solid({ ssr: ${shouldUseSSR}, adapter: vercel({ edge: false }) })]`;
-  return `import solid from "solid-start/vite";${
+  return `import solid from "solid-start/vite";
+import dotenv from "dotenv";${
     useUno ? `\nimport UnoCSS from "unocss/vite";` : ""
   }
 import { defineConfig } from "vite";${
@@ -25,9 +26,9 @@ import vercel from "solid-start-vercel";`
   }
   
 export default defineConfig(() => {
+  dotenv.config();
   return {
     plugins: ${plugins},
-    envDir: __dirname,
   };
 });
   `;

--- a/template/base/README.MD
+++ b/template/base/README.MD
@@ -25,7 +25,6 @@ export default defineConfig(() => {
   dotenv.config();
   return {
     plugins: [solid({ ssr: false, adapter: vercel({ edge: false }) })],
-    envDir: __dirname,
   };
 });
 ```

--- a/template/base/package.json
+++ b/template/base/package.json
@@ -22,6 +22,7 @@
     "solid-js": "^1.5.7",
     "solid-start": "^0.2.1",
     "undici": "5.11.0",
+    "dotenv": "^16.0.3",
     "zod": "^3.19.1"
   },
   "engines": {

--- a/template/base/vite.config.ts
+++ b/template/base/vite.config.ts
@@ -1,9 +1,10 @@
 import solid from "solid-start/vite";
+import dotenv from "dotenv";
 import { defineConfig } from "vite";
 
 export default defineConfig(() => {
+  dotenv.config();
   return {
     plugins: [solid({ ssr: false })],
-    envDir: __dirname,
   };
 });


### PR DESCRIPTION
Reverts OrJDev/create-jd-app#11