### PR TITLE
Fix vite config (when using tRPC)

### DIFF
--- a/src/helpers/vite.ts
+++ b/src/helpers/vite.ts
@@ -13,7 +13,7 @@ export const getViteConfig: IUtil = (ctx) => {
     ]`
       : useUno
       ? `[solid({ ssr: ${shouldUseSSR} }), UnoCSS()]`
-      : `[solid({ ssr: ${shouldUseSSR}, adapter: vercel({ edge: false }) })]`;
+      : `[solid({ ssr: ${shouldUseSSR} })]`;
   return `import solid from "solid-start/vite";
 import dotenv from "dotenv";${
     useUno ? `\nimport UnoCSS from "unocss/vite";` : ""

--- a/src/helpers/vite.ts
+++ b/src/helpers/vite.ts
@@ -18,8 +18,7 @@ export const getViteConfig: IUtil = (ctx) => {
 import dotenv from "dotenv";${
     useUno ? `\nimport UnoCSS from "unocss/vite";` : ""
   }
-import { defineConfig } from "vite";
-import dotenv from "dotenv";${
+import { defineConfig } from "vite";${
     ctx.vercel
       ? `\n// @ts-expect-error no typing
 import vercel from "solid-start-vercel";`

--- a/src/helpers/vite.ts
+++ b/src/helpers/vite.ts
@@ -5,15 +5,20 @@ import { ICtx, IUtil } from "~types";
 export const getViteConfig: IUtil = (ctx) => {
   const useUno = ctx.installers.includes("UnoCSS");
   const shouldUseSSR = !ctx.installers.includes("tRPC");
-  const plugins =
-    useUno && ctx.vercel
-      ? `[
-      solid({ ssr: ${shouldUseSSR}, adapter: vercel({ edge: false }) }),
-      UnoCSS(),
-    ]`
-      : useUno
-      ? `[solid({ ssr: ${shouldUseSSR} }), UnoCSS()]`
-      : `[solid({ ssr: ${shouldUseSSR} })]`;
+  const plugins = (() => {
+    if (useUno && ctx.vercel) {
+      return `[
+        solid({ ssr: ${shouldUseSSR}, adapter: vercel({ edge: false }) }),
+        UnoCSS(),
+      ]`;
+    } else if (useUno) {
+      return `[solid({ ssr: ${shouldUseSSR} }), UnoCSS()]`;
+    } else if (ctx.vercel) {
+      return `[solid({ ssr: ${shouldUseSSR}, adapter: vercel({ edge: false }) })]`;
+    } else {
+      return `[solid({ ssr: ${shouldUseSSR} })]`;
+    }
+  })();
   return `import solid from "solid-start/vite";
 import dotenv from "dotenv";${
     useUno ? `\nimport UnoCSS from "unocss/vite";` : ""


### PR DESCRIPTION
I noticed 2 problems in vite config when I was creating a new project using create-jd-app (which looks great btw): 
- Firstly `import dotenv from "dotenv";` is included twice 
- Secondly when using trpc and not vercel or unocss, the vercel adapter is still added, preventing running the app


![image](https://user-images.githubusercontent.com/73063460/202869270-7a32c245-3a15-4925-b17d-05350fa007e0.png)
