### PR TITLE
fix: typo in solidauth discord username, import User without prisma

### DIFF
--- a/src/installers/SolidAuth/files/prisma-handler.txt
+++ b/src/installers/SolidAuth/files/prisma-handler.txt
@@ -1,4 +1,5 @@
-import { authenticator, type User } from "~/server/auth";
+import { type User } from "@prisma/client";
+import { authenticator } from "~/server/auth";
 import { createSolidAuthHandler } from "solidjs-auth";
 
 const handler = createSolidAuthHandler<User>(authenticator);

--- a/src/installers/SolidAuth/files/server.txt
+++ b/src/installers/SolidAuth/files/server.txt
@@ -2,7 +2,7 @@ import { Authenticator, DiscordStrategy } from "solidjs-auth";
 import { serverEnv } from "~/env/server";
 import { sessionStorage } from "~/utils/auth";
 
-type User = {
+export type User = {
   id: string;
   displayName: string;
   avatar?: string;
@@ -22,7 +22,7 @@ export const authenticator = new Authenticator<User>(sessionStorage).use(
       if (!user) {
         user = {
           id: profile.id,
-          displayName: profile.username,
+          displayName: profile.__json.username,
           avatar: profile.photos[0].value,
         };
         users.push(user);

--- a/src/installers/SolidAuth/index.ts
+++ b/src/installers/SolidAuth/index.ts
@@ -17,7 +17,9 @@ const config: IInstaller = (ctx) => ({
       to: `${ctx.userDir}/src/utils/auth.ts`,
     },
     {
-      path: `${__dirname}/files/handler.txt`,
+      path: `${__dirname}/files/${
+        ctx.installers.includes("Prisma") ? "prisma-handler" : "handler"
+      }.txt`,
       to: `${ctx.userDir}/src/routes/api/auth/[...solidauth].ts`,
     },
     ...(ctx.installers.includes("tRPC")


### PR DESCRIPTION
closes #17 

1. fix a typo in the `src/server/auth.ts` when passing the username from discord
2. create `handler.txt` and `prisma-handler.txt` that ensures `[...solidauth].ts` file imports `User` type from appropriate file based on whether prisma is installed