### PR TITLE
typo in "Ran queued commands" when using npm

### DIFF
--- a/src/utils/project.ts
+++ b/src/utils/project.ts
@@ -183,7 +183,7 @@ export function finished(ctx: ICtx) {
   ctx.installers.includes("Prisma") &&
     console.log(
       `${chalk.yellow(
-        `\t${ctx.pkgManager}${ctx.pkgManager === "pnpm" ? "" : "run"} push`
+        `\t${ctx.pkgManager}${ctx.pkgManager === "pnpm" ? "" : " run"} push`
       )}\t${chalk.gray("// pushes db to Prisma")}`
     );
   console.log(chalk.bold(chalk.blue(`\t${ctx.pkgManager} run dev`)));


### PR DESCRIPTION
If we use npm, the command looks like "npmrun push"

<img width="379" alt="Screenshot 2023-01-09 at 21 56 34" src="https://user-images.githubusercontent.com/20075941/211406731-dc9898e0-86fc-460d-a51b-1e60b6651703.png">

I just added a whitespace :)