### PR TITLE
Create app in current directory

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pmpm lint-staged
+pnpm lint-staged

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -42,6 +42,7 @@ async function execFile(file: IFile, ctx: ICtx) {
 }
 
 export async function existsOrCreate(path: string): Promise<boolean> {
+  if(process.cwd() === path) return fs.readdirSync(path).length === 0 ? false : true;
   try {
     await fs.access(path);
     return true;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -30,7 +30,7 @@ export const formatError = (err: unknown): string => {
 
 export const validateName = (name: string) => {
   if (!name.length) return false;
-  return /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name)
+  return /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?([a-z0-9-~][a-z0-9-._~]*)$|(^\.$)/.test(name)
     ? true
     : "This is not a valid name";
 };

--- a/src/utils/project.ts
+++ b/src/utils/project.ts
@@ -37,7 +37,7 @@ export async function initApp(args: string[]): Promise<IAppCtx> {
         default: "my-app",
       })
     ).appName;
-  const userDir = path.resolve(process.cwd(), appName);
+  const userDir = path.resolve(process.cwd(), appName === "." ? "" : appName);
   const exists = await existsOrCreate(userDir);
   if (exists) {
     if (
@@ -179,7 +179,7 @@ export async function runCommands(ctx: IAppCtx, commands: string[]) {
 }
 
 export function finished(ctx: ICtx) {
-  console.log(`\n\t${chalk.green(`cd ${ctx.appName}`)}`);
+  ctx.appName !== "." && console.log(`\n\t${chalk.green(`cd ${ctx.appName}`)}`);
   const withRun = ctx.pkgManager === "pnpm" ? "" : " run";
   ctx.installers.includes("Prisma") &&
     console.log(


### PR DESCRIPTION
Allows the user to create the app in the directory they are currently in by setting (.) as the project name

Also fixed a little typo in the precommit hook