### PR TITLE
Add UnoCSS preset and preflight for better styling consistency

### DIFF
--- a/.changeset/healthy-falcons-sell.md
+++ b/.changeset/healthy-falcons-sell.md
@@ -1,0 +1,5 @@
+---
+"create-jd-app": patch
+---
+
+Add UnoCSS preset and preflight for better styling consistency

--- a/src/installers/UnoCSS/files/config.txt
+++ b/src/installers/UnoCSS/files/config.txt
@@ -1,5 +1,6 @@
-import { defineConfig, transformerVariantGroup  } from "unocss";
+import { defineConfig, transformerVariantGroup, presetUno } from "unocss";
 
 export default defineConfig({
-  transformers: [transformerVariantGroup()],
+	presets: [presetUno()],
+	transformers: [transformerVariantGroup()],
 });

--- a/src/installers/UnoCSS/files/root.txt
+++ b/src/installers/UnoCSS/files/root.txt
@@ -1,6 +1,7 @@
 // @refresh reload
 import "./root.css";
 import "uno.css";
+import "@unocss/reset/tailwind.css";
 import { Suspense } from "solid-js";
 import {
   Body,


### PR DESCRIPTION
Defining a preset isn't necessary, but it's helpful to indicate which preset is being used.
Additionally, I've added the Tailwind's preflight since UnoCSS doesn't include any style normalization by default.