### PR TITLE
Prevent UnoCSS imports being overwritten by TRPC/PRPC root.tsx

### DIFF
--- a/.changeset/light-poets-happen.md
+++ b/.changeset/light-poets-happen.md
@@ -1,0 +1,5 @@
+---
+"create-jd-app": patch
+---
+
+prevent UnoCSS imports being overwritten by TRPC/PRPC addon

--- a/src/installers/pRPC/index.ts
+++ b/src/installers/pRPC/index.ts
@@ -12,7 +12,8 @@ const config: IInstaller = (ctx) => {
         to: `${ctx.userDir}/src/server/queries.ts`,
       },
       {
-        path: `${__dirname}/files/root.txt`,
+        path: `${__dirname}/utils/getRoot`,
+        type: "exec",
         to: `${ctx.userDir}/src/root.tsx`,
       },
     ],

--- a/src/installers/pRPC/utils/getRoot.ts
+++ b/src/installers/pRPC/utils/getRoot.ts
@@ -1,5 +1,14 @@
-// @refresh reload
+import { type IUtil } from "~types";
+
+const getRoot: IUtil = (ctx) => {
+  const useUno = ctx.installers.includes("UnoCSS");
+
+  return `// @refresh reload
 import "./root.css";
+${useUno ?
+`import "uno.css";
+import "@unocss/reset/tailwind.css";
+` : ""}
 import { Suspense } from "solid-js";
 import {
   Body,
@@ -44,3 +53,7 @@ export default function Root() {
     </Html>
   );
 }
+`;
+};
+
+export default getRoot;

--- a/src/installers/tRPC/utils/getRoot.ts
+++ b/src/installers/tRPC/utils/getRoot.ts
@@ -1,8 +1,14 @@
 import { type IUtil } from "~types";
 
 const getRoot: IUtil = (ctx) => {
+  const useUno = ctx.installers.includes("UnoCSS");
+
   return `// @refresh reload
 import "./root.css";
+${useUno ?
+`import "uno.css";
+import "@unocss/reset/tailwind.css";
+` : ""}
 import { Suspense } from "solid-js";
 import {
   Body,


### PR DESCRIPTION
Fixed an issue where the root file in the UnoCSS addon was being overwritten when combined with the trpc/prpc addon.